### PR TITLE
Enhance viewer and package import reliability

### DIFF
--- a/openephysextract/__init__.py
+++ b/openephysextract/__init__.py
@@ -1,1 +1,9 @@
-from .extractor import Extractor
+try:
+    from .extractor import Extractor
+except Exception:
+    Extractor = None
+from .viewer import Viewer
+from .preprocess import Preprocessor
+from .trial import Trial
+
+__all__ = [name for name in ["Extractor", "Viewer", "Preprocessor", "Trial"] if globals().get(name) is not None]

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,16 @@
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import sys
+sys.path.insert(0, '.')
+from openephysextract.viewer import Viewer
+
+def test_plot_eeg_runs():
+    n_channels = 2
+    n_samples = 3300
+    n_events = 3
+    data = np.random.randn(n_channels, n_samples, n_events)
+    extracted = [{'data': data, 'notes': {'currentLevel': [1]*n_events, 'session': 'demo'}}]
+    viewer = Viewer(extracted, sampling_rate=1000)
+    fig, delays = viewer.plot_eeg(0)
+    assert 'positive peaks' in delays and 'negative peaks' in delays


### PR DESCRIPTION
## Summary
- avoid failing imports when optional dependencies like `open_ephys` are missing
- fix current-level broadcasting bug in Viewer and tests
- add a basic unit test for `Viewer.plot_eeg`

## Testing
- `pytest -q`
- `python - <<'EOFPY'
import openephysextract as oe
print('ok')
EOFPY
`

------
https://chatgpt.com/codex/tasks/task_e_68404a8f74148322a9e23fb68f99436b